### PR TITLE
Implement BringIndexIntoView in VirtualizingStackPanel

### DIFF
--- a/Digimezzo.WPFControls/VirtualizingWrapPanel.cs
+++ b/Digimezzo.WPFControls/VirtualizingWrapPanel.cs
@@ -188,6 +188,17 @@ namespace Digimezzo.WPFControls
             base.OnClearChildren();
             this.SetVerticalOffset(0);
         }
+
+        protected override void BringIndexIntoView(int index)
+        {
+            if (index < 0 || index >= Children.Count)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+            int childrenPerRow = CalculateChildrenPerRow(RenderSize);
+            int row = index / childrenPerRow;
+            SetVerticalOffset(row * ChildHeight);
+        }
         #endregion
 
         #region Private


### PR DESCRIPTION
Implemented `BringIndexIntoView(int index)` in `VirtualizingStackPanel`. This fixes an issue where `ListBox` `ScrollIntoView` (or similar) did not cause the `ListBox` to be scrolled.

See more information in MSDN docs [here](https://msdn.microsoft.com/en-us/library/system.windows.controls.virtualizingstackpanel.bringindexintoview(v=vs.110).aspx).

Edit: Shouldn't need to Math.Floor the result of the row calculation -- see [here](http://stackoverflow.com/a/3090649/3938401).